### PR TITLE
Docker を使って MySQL を構築しました

### DIFF
--- a/docker-mysql-mining-game/Dockerfile
+++ b/docker-mysql-mining-game/Dockerfile
@@ -1,0 +1,7 @@
+FROM mysql:8.0-debian
+RUN apt-get update
+RUN apt-get -y install locales-all
+ENV LANG ja_JP.UTF-8
+ENV LANGUAGE ja_JP:ja
+ENV LC_ALL ja_JP.UTF-8
+COPY ./conf/mysql/my.cnf /etc/my.cnf

--- a/docker-mysql-mining-game/conf/mysql/my.cnf
+++ b/docker-mysql-mining-game/conf/mysql/my.cnf
@@ -1,0 +1,11 @@
+[mysqld]
+skip-character-set-client-handshake
+default-time-zone='+9:00'
+character-set-server = utf8mb4
+collation-server = utf8mb4_general_ci
+slow_query_log = 1
+slow_query_log_file = /var/log/slow_query.log
+long_query_time = 1
+
+[client]
+default-character-set = utf8mb4

--- a/docker-mysql-mining-game/docker-compose.yml
+++ b/docker-mysql-mining-game/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'  # docker-compose のバージョン
+services:
+  db:
+    build: .
+    container_name: docker-mysql-mining-game
+    platform: linux/x86_64
+    command: --default-authentication-plugin=mysql_native_password
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: rootroot  # ルートパスワードの設定
+      MYSQL_DATABASE: mydatabase  # 作成するデータベース名
+    ports:
+      - "3307:3306"  # ポートマッピング（ホスト:コンテナ）
+    volumes:
+      - my-db:/var/lib/mysql  # データの永続化
+volumes:
+  my-db:

--- a/docker-mysql-mining-game/docker-compose.yml
+++ b/docker-mysql-mining-game/docker-compose.yml
@@ -7,11 +7,13 @@ services:
     command: --default-authentication-plugin=mysql_native_password
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: rootroot  # ルートパスワードの設定
-      MYSQL_DATABASE: mydatabase  # 作成するデータベース名
+      - TZ=Asia/Tokyo
+      - MYSQL_ROOT_PASSWORD=rootroot  # ルートパスワードの設定
+      - MYSQL_DATABASE=spigot_server  # 作成するデータベース名
     ports:
       - "3307:3306"  # ポートマッピング（ホスト:コンテナ）
     volumes:
+      - ./sql:/docker-entrypoint-initdb.d
       - my-db:/var/lib/mysql  # データの永続化
 volumes:
   my-db:

--- a/docker-mysql-mining-game/sql/001-create-table-and-load-data.sql
+++ b/docker-mysql-mining-game/sql/001-create-table-and-load-data.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS mininggame_score;
+
+CREATE TABLE mininggame_score (
+  id int unsigned AUTO_INCREMENT,
+  player_name VARCHAR(100) NOT NULL,
+  score int,
+  registered_at datetime NOT NULL,
+  PRIMARY KEY(id)
+);
+
+INSERT INTO mininggame_score (player_name, score, registered_at) VALUES ("TestUser", 1000, now());

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -11,7 +11,7 @@
       <transactionManager type="JDBC"/>
       <dataSource type="POOLED">
         <property name="driver" value="com.mysql.cj.jdbc.Driver"/>
-        <property name="url" value="jdbc:mysql://localhost:3306/spigot_server"/>
+        <property name="url" value="jdbc:mysql://localhost:3307/spigot_server"/>
         <property name="username" value="root"/>
         <property name="password" value="rootroot"/>
       </dataSource>


### PR DESCRIPTION
### 概要
Docker を使って MySQL を構築しました

### 変更理由
異なる環境で動作させる場合に、MySqlサーバーを毎回設定する手間を解消するため

### 実施内容
- Yoshihito Koyamaさんのハンズオンを参考にdockerのコンテナ構成情報をdocker-compose.ymlに記載しました